### PR TITLE
Add Inchoo_SocialConnect module

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -366,6 +366,7 @@
       { "type": "vcs", "url": "git://github.com/miguelbalparda/MB_Translate.git" },
       { "type": "vcs", "url": "git://github.com/mage-eag/mage-enhanced-admin-grids.git" },
       { "type": "vcs", "url": "git://github.com/Strategery-Inc/Magento-InfiniteScroll.git" },
+      { "type": "vcs", "url": "git://github.com/Marko-M/Inchoo_SocialConnect.git" },
       { "type": "composer", "url": "http://packages.fooman.co.nz/" },
       { "type": "composer", "url": "http://packages.firegento.com/connect20/" },
 		{


### PR DESCRIPTION
Add Inchoo_SocialConnect module. This is Magento extension allowing store customers to login or create account at store using their Google, Facebook, Twitter or LinkedIn account.
